### PR TITLE
Allow users to pass in auditConfiguration objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,27 @@ Enable this plugin in your config file:
       ...
       plugins: [{
         chromeA11YDevTools: {
-          treatWarningsAsFailures: true
+          treatWarningsAsFailures: true,
+          auditConfiguration: {
+            auditRulesToRun: [
+              'audioWithoutControls',
+              'badAriaAttributeValue',
+              'badAriaRole',
+              'controlsWithoutLabel',
+              'elementsWithMeaningfulBackgroundImage',
+              'focusableElementNotVisibleAndNotAriaHidden',
+              'imagesWithoutAltText',
+              'linkWithUnclearPurpose',
+              'lowContrastElements',
+              'mainRoleOnInappropriateElement',
+              'nonExistentAriaLabelledbyElement',
+              'pageWithoutTitle',
+              'requiredAriaAttributeMissing',
+              'unfocusableElementsWithOnClick',
+              'videoWithoutCaptions'
+            ],
+            auditRulesToSkip: []
+          }
         },
         package: 'protractor-accessibility-plugin'
       }]

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var q = require('q'),
     fs = require('fs'),
     path = require('path'),
-    _ = require('lodash');
+    _ = require('lodash'),
     request = require('request'),
     Entities = require('html-entities').XmlEntities;
 
@@ -148,7 +148,7 @@ function runTenonIO(context) {
 function runChromeDevTools(context) {
 
   var data = fs.readFileSync(AUDIT_FILE, 'utf-8');
-  data = data + ' return axs.Audit.run();';
+  data = data + ' var configuration = new axs.AuditConfiguration(' + JSON.stringify(context.config.chromeA11YDevTools.auditConfiguration) + '); return axs.Audit.run(configuration);';
 
   var elementPromises = [],
       elementStringLength = 200;


### PR DESCRIPTION
Allow users to configure https://github.com/GoogleChrome/accessibility-developer-tools

Also fixed a typo (replace `;` with `,`) which was causing the plugin to fail.
