### PR TITLE
Run audits on every page

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var TENON_URL = 'http://www.tenon.io/api/';
  * @return {q.Promise} A promise which resolves when all audits are finished
  * @public
  */
-function teardown() {
+function runAudits() {
 
   var audits = [];
 
@@ -66,6 +66,13 @@ function teardown() {
     audits.push(runTenonIO(this));
   }
   return q.all(audits);
+}
+
+// Run audits on page load if we're not waiting for angular.
+function onPageLoad() {
+  if (browser.ignoreSynchronization) {
+    runAudits();
+  }
 }
 
 var entities = new Entities();
@@ -229,4 +236,5 @@ function runChromeDevTools(context) {
 }
 
 // Export
-exports.teardown = teardown;
+exports.onPageLoad = onPageLoad;
+exports.onPageStable = runAudits;


### PR DESCRIPTION
Thanks for the awesome plugin! One question: Why are audits run on teardown and not against every page? In our project it makes more sense to run them on every page load instead of just on the last page at the very end.

It's pretty easy to run them against every page (see this PR) but I'm guessing there was a reason this plugin wasn't implemented this way?
