### PR TITLE
Add Protractor 4.x support

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function runChromeDevTools(context) {
 
   var testHeader = 'Chrome A11Y - ';
 
-  return browser.executeScript_(data, 'a11y developer tool rules').then(function(results) {
+  return browser.executeScriptWithDescription(data, 'a11y developer tool rules').then(function(results) {
 
     var audit = results.map(function(result) {
       var DOMElements = result.elements;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "httpster": "^1.0.1",
-    "protractor": "^2.5.1"
+    "protractor": "^4.0.10"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 var Executor = require('./test_util').Executor;
 
 var passingTests = [
-  'node node_modules/protractor/lib/cli.js spec/successConfig.js',
+  'node node_modules/protractor/bin/protractor spec/successConfig.js',
 ];
 
 var executor = new Executor();
@@ -18,7 +18,7 @@ passingTests.forEach(function(passing_test) {
  *************************/
 
 executor.addCommandlineTest(
-    'node node_modules/protractor/lib/cli.js spec/failureConfig.js')
+    'node node_modules/protractor/bin/protractor spec/failureConfig.js')
     .expectExitCode(1)
     .expectErrors([{
       message: '3 elements failed:'


### PR DESCRIPTION
`executeScript_` became `executeScript` in Protractor 4.x

Fixes #12.
