### PR TITLE
Upgrade axa and protractor versions to latest stables

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "accessibility-developer-tools": "^2.9.0-rc.0",
     "axe-core": "^2.0.5",
-    "axe-webdriverjs": "^0.2.0",
+    "axe-webdriverjs": "^0.5.0",
     "html-entities": "^1.2.0",
     "lodash": "^3.10.1",
     "q": "^1.4.1",
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "httpster": "^1.0.1",
-    "protractor": "^4.0.10"
+    "protractor": "^5.0.1"
   }
 }


### PR DESCRIPTION
This commit bump axa webdriver support and make it possible to shrinkwrap the plugin in projects using latest protractor.

Fixes #25