### PR TITLE
Fix example configurations in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,6 @@ Enable this plugin in your config file:
       plugins: [{
         chromeA11YDevTools: {
           treatWarningsAsFailures: true,
-          auditConfiguration: {
-            auditRulesToRun: [
-              'audioWithoutControls',
-              'badAriaAttributeValue',
-              'badAriaRole',
-              'controlsWithoutLabel',
-              'elementsWithMeaningfulBackgroundImage',
-              'focusableElementNotVisibleAndNotAriaHidden',
-              'imagesWithoutAltText',
-              'linkWithUnclearPurpose',
-              'lowContrastElements',
-              'mainRoleOnInappropriateElement',
-              'nonExistentAriaLabelledbyElement',
-              'pageWithoutTitle',
-              'requiredAriaAttributeMissing',
-              'unfocusableElementsWithOnClick',
-              'videoWithoutCaptions'
-            ],
-            auditRulesToSkip: []
-          }
         },
         package: 'protractor-accessibility-plugin'
       }]
@@ -91,7 +71,6 @@ Enable this plugin in your config file:
           },
           printAll: false, // whether the plugin should log API response
         },
-        chromeA11YDevTools: true,
         package: 'protractor-accessibility-plugin'
       }]
     }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,15 @@ var q = require('q'),
  *      }]
  *    }
  *
+ *   // aXe:
+ *   exports.config = {
+ *     ...
+ *     plugins: [{
+ *       axe: true,
+ *       package: 'protractor-accessibility-plugin'
+ *     }]
+ *   }
+ * 
  *    // Tenon.io:
  *
  *    //  Read about the Tenon.io settings and API requirements:
@@ -36,7 +45,6 @@ var q = require('q'),
  *          },
  *          printAll: false, // whether the plugin should log API response
  *        },
- *        chromeA11YDevTools: false,
  *        path: 'node_modules/protractor/plugins/accessiblity'
  *      }]
  *    }


### PR DESCRIPTION
1. Removed Chrome a11y config from Tenon example in README
2. Removed broken config options from Chrome a11y example in README
3. Added aXe example to index.js
